### PR TITLE
修复 ThinkJS 模板并发报错的问题

### DIFF
--- a/thinkjs-starter/cloudbase.js
+++ b/thinkjs-starter/cloudbase.js
@@ -10,11 +10,10 @@ const instance = new Application({
   proxy: true, // use proxy
   env: 'cloudbase'
 });
+const loader = new Loader(instance.options);
+loader.loadAll('worker');
 
 exports.tcbGetApp = async () => {
-  const loader = new Loader(instance.options);
-  loader.loadAll('worker');
-
   await think.beforeStartServer().catch(err => think.logger.error(err));
   await instance._getWorkerInstance(instance.parseArgv());
   think.app.emit('appReady');


### PR DESCRIPTION
`loadAll()` 方法会将相关文件状态并挂载到 `globalThis.think` 全局实例下。如果按照线下沟通的是多次执行的环境复用形式的话，可能会在 `tcbGetApp()` 多次执行时重复装载导致问题。目前将其迁移至函数外部后，自测没有出现线下沟通的中间件报错的问题。

测试地址： https://waline-2gk8d5jw219ba8c7-1252157872.ap-shanghai.service.tcloudbase.com/thinkjs-starter