### PR TITLE
[fix] add default TCB_ENV_ID

### DIFF
--- a/vue/src/main.js
+++ b/vue/src/main.js
@@ -2,7 +2,8 @@ import Vue from "vue";
 import App from "./App.vue";
 import Cloudbase from "@cloudbase/vue-provider";
 
-window._tcbEnv = window._tcbEnv || {};
+// 注意更新此处的TCB_ENV_ID为你自己的环境ID
+window._tcbEnv = window._tcbEnv || {TCB_ENV_ID:"hello-cloudbase-test"};
 
 export const envId = window._tcbEnv.TCB_ENV_ID;
 export const region = window._tcbEnv.TCB_REGION;


### PR DESCRIPTION
add default value for TCB_ENV_ID, prevent triggering "envId not set" error from debugging Vue app on user's PC. more info can be found in issue #66